### PR TITLE
micro lite & micro express support added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,19 @@
-obj-m := motu.o
+KERNELDIR = /usr/src/linux
+#CFLAGS = -D__KERNEL__ -DMODULE -I$(KERNELDIR)/include -O
+EXTRA_CFLAGS = -Wall #-DCONFIG_SND_DEBUG
+
+ifneq ($(KERNELRELEASE),)
+
+obj-m	:= motu.o
+
+else
+
+KDIR	:= /lib/modules/$(shell uname -r)/build
+PWD	:= $(shell pwd)
+
+default:
+	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) modules
+endif
+
+clean:
+	rm -f *.[oas] *.ko *.mod.c modules.* Module.*


### PR DESCRIPTION
Hi,

as already said, this update supports the "small" motus.
I've made a lot of tests (midi-controller and midi-soundfiles, also in loopback configuration) without any problems still now.
Tested with Slackware 14.2 and 4.4.14 Kernel.

I think the 128 must still working, but it is untested. The express XT is not supported for the moment. I dont have accces to this devices.