### PR TITLE
kernal 6.8: replace strlcpy with strscpy

### DIFF
--- a/motu.c
+++ b/motu.c
@@ -774,7 +774,7 @@ static int motu_init_midi(struct motu *motu)
 	if (ret < 0)
 		return ret;
 
-	strncpy(rmidi->name, motu->card->shortname, sizeof(rmidi->name));
+	strscpy(rmidi->name, motu->card->shortname, sizeof(rmidi->name));
 
 	rmidi->info_flags = SNDRV_RAWMIDI_INFO_DUPLEX;
 	rmidi->private_data = motu;


### PR DESCRIPTION
Kernel 6.8.x has [removed](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=57f22c8dab6b266ae36b89b073a4a33dea71e762) `strlcpy()`. This patch updates `motu.c` to use `strscpy()` instead. Compiling with `strlcpy()` on 6.8.x fails with an `implicit declaration` error:

```
/home/mark/src/motu/motu.c: In function ‘motu_init_midi’:
/home/mark/src/motu/motu.c:777:9: error: implicit declaration of function ‘strlcpy’; did you mean ‘strscpy’? [-Werror=implicit-function-declaration]
  777 |         strlcpy(rmidi->name, motu->card->shortname, sizeof(rmidi->name));
      |         ^~~~~~~
      |         strscpy
cc1: some warnings being treated as errors
make[2]: *** [scripts/Makefile.build:243: /home/mark/src/motu/motu.o] Error 1
make[1]: *** [/usr/src/linux-headers-6.8.0-50-lowlatency/Makefile:1925: /home/mark/src/motu] Error 2
make: *** [Makefile:240: __sub-make] Error 2
make: Leaving directory '/usr/src/linux-headers-6.8.0-50-lowlatency'
```

I'm not currently able to test this on pre-6.8.x kernels but `strscpy()` has been around for a while already so hopefully it's ok.